### PR TITLE
Add cookie auth, CSRF, and 401-refresh hooks to DevengNetworkingConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ val config = DevengNetworkingConfig(
     requestTimeoutMillis = 30_000L,               // Optional - defaults to 60 seconds
     connectTimeoutMillis = 10_000L,               // Optional - defaults to 10 seconds
     socketTimeoutMillis = 30_000L,                // Optional - defaults to 60 seconds
-    token = "your-auth-token",                    // Optional - for authentication
+    token = "your-auth-token",                    // Optional - for Bearer auth (omit for cookie-only)
     locale = Locale.EN,                           // Optional - defaults to EN
     customHeaders = mapOf(                        // Optional - for global headers
         "X-API-Version" to "1.0",
@@ -74,7 +74,7 @@ suspend fun getUser(userId: String): User {
 | 📁 **File Upload Support** | Simple multipart file uploads with MIME detection |
 | 🔄 **WebSocket Management** | Connection pooling, lifecycle events, automatic reconnection |
 | 🎯 **Multiplatform** | Android, iOS, Desktop (JVM), WebAssembly |
-| 🔒 **Authentication** | Built-in token-based authentication |
+| 🔒 **Authentication** | Bearer tokens, cookie sessions, CSRF, and refresh-on-401 |
 | 🌍 **Localization** | Localized error messages and headers |
 | 🎭 **Error Handling** | Centralized, customizable exception handling |
 | 🛠️ **Dynamic Parameters** | Path and query parameter injection |
@@ -403,6 +403,56 @@ class CustomExceptionHandler : ExceptionHandler {
 // Update authentication token at runtime
 DevengNetworkingModule.setToken("new-auth-token")
 ```
+
+When the token is blank (`""`), DNM omits the `Authorization` header entirely rather than sending an empty `Authorization: Bearer ` value — useful for cookie-only auth flows.
+
+### Cookie-Based Sessions
+
+Install Ktor's `HttpCookies` plugin with a custom `CookiesStorage` to persist cookies across requests (and across process restarts, if your storage writes to disk):
+
+```kotlin
+val config = DevengNetworkingConfig(
+    httpClientConfig = {
+        install(HttpCookies) {
+            storage = MyPersistentCookiesStorage()
+        }
+    },
+    wasmJsIncludeCredentials = true               // Required on wasmJs for cross-origin cookies
+)
+```
+
+`httpClientConfig` is a generic Ktor `HttpClient` extension point — install any plugin you need, not just `HttpCookies`. `wasmJsIncludeCredentials` is engine-level and only relevant on the wasmJs target.
+
+### CSRF Protection
+
+Attach a CSRF token header on every POST, PUT, PATCH, DELETE. The provider is called once per mutating request; a `null` return skips the header for that request:
+
+```kotlin
+val config = DevengNetworkingConfig(
+    csrfTokenProvider = DevengCsrfTokenProvider { myCsrfStore.getToken() },
+    csrfHeaderName = "X-CSRF-TOKEN"               // Optional - defaults to "X-CSRF-TOKEN"
+)
+```
+
+### Handling 401 Responses
+
+Two opt-in hooks fire on HTTP 401. `sessionRefresher` runs first and can recover the session transparently by refreshing and retrying the original request; `onUnauthorized` runs only when recovery fails (or isn't configured) and is intended for global UI reactions:
+
+```kotlin
+val config = DevengNetworkingConfig(
+    sessionRefresher = DevengSessionRefresher {
+        try {
+            authService.refreshSession()
+            true                                  // Retry the failed request
+        } catch (e: Exception) {
+            false                                 // Surface UnauthorizedError
+        }
+    },
+    onUnauthorized = { eventBus.emit(SessionExpired) }
+)
+```
+
+Concurrent 401s are deduplicated by a per-client mutex + generation counter, so only one refresh runs even under heavy parallel load. The refresher can issue HTTP calls through the same DNM client without infinite recursion — an internal coroutine-context marker suppresses re-entrance.
 
 ### Version Catalog Setup
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ android-minSdk = "24"
 android-compileSdk = "36"
 app-version-major = "2"
 app-version-code = "13"
-app-minor-version = "68"
+app-minor-version = "69"
 kotlin-serialization = "1.8.0"
 
 compose-plugin = "1.9.3"

--- a/networking/src/commonMain/kotlin/DevengNetworkingModule.kt
+++ b/networking/src/commonMain/kotlin/DevengNetworkingModule.kt
@@ -5,20 +5,24 @@ import error_handling.DevengException
 import error_handling.DevengUiError
 import error_handling.ErrorKey
 import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
 import io.ktor.client.call.body
 import io.ktor.client.request.request
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
+import networking.csrf.DevengCsrfTokenProvider
 import networking.di.CoreModule
 import networking.exception_handling.ExceptionHandler
 import networking.localization.Locale
 import networking.localization.LocalizationManager
+import networking.session.DevengSessionRefresher
 import networking.util.DevengHttpMethod
 import networking.util.buildRequestUrl
 import networking.util.setupAllHeaders
@@ -39,7 +43,13 @@ public data class DevengNetworkingConfig(
     val locale: Locale? = null,
     val customHeaders: Map<String, String> = emptyMap(),
     val socketBaseUrl: String = "",
-    val customErrorMessages: Map<Locale, Map<ErrorKey, String>>? = null
+    val customErrorMessages: Map<Locale, Map<ErrorKey, String>>? = null,
+    val wasmJsIncludeCredentials: Boolean = false,
+    val onUnauthorized: (() -> Unit)? = null,
+    val sessionRefresher: DevengSessionRefresher? = null,
+    val csrfTokenProvider: DevengCsrfTokenProvider? = null,
+    val csrfHeaderName: String = "X-CSRF-TOKEN",
+    val httpClientConfig: (HttpClientConfig<*>.() -> Unit)? = null
 )
 
 public class DevengNetworkingModule {
@@ -88,6 +98,10 @@ public class DevengNetworkingModule {
         config = config?.copy(token = newToken)
     }
 
+    public fun notifyUnauthorized() {
+        config?.onUnauthorized?.invoke()
+    }
+
     public suspend inline fun <reified T, reified R> sendRequest(
         endpoint: String,
         requestBody: T? = null,
@@ -133,6 +147,10 @@ public class DevengNetworkingModule {
                 response.status.isSuccess() -> response.body() as R
 
                 else -> {
+                    if (response.status == HttpStatusCode.Unauthorized) {
+                        notifyUnauthorized()
+                    }
+
                     var errorResponse: ErrorResponse? = null
                     try {
                         errorResponse = sharedJson?.decodeFromString<ErrorResponse>(response.body())
@@ -209,6 +227,10 @@ public class DevengNetworkingModule {
                 )
 
                 else -> {
+                    if (response.status == HttpStatusCode.Unauthorized) {
+                        notifyUnauthorized()
+                    }
+
                     var errorResponse: ErrorResponse? = null
                     try {
                         errorResponse =
@@ -283,6 +305,10 @@ public class DevengNetworkingModule {
                 response.status.isSuccess() -> response
 
                 else -> {
+                    if (response.status == HttpStatusCode.Unauthorized) {
+                        notifyUnauthorized()
+                    }
+
                     var errorResponse: ErrorResponse? = null
                     try {
                         errorResponse = sharedJson?.decodeFromString<ErrorResponse>(response.body())

--- a/networking/src/commonMain/kotlin/csrf/DevengCsrfTokenProvider.kt
+++ b/networking/src/commonMain/kotlin/csrf/DevengCsrfTokenProvider.kt
@@ -1,0 +1,12 @@
+package networking.csrf
+
+/**
+ * Supplies a CSRF token for mutating requests.
+ *
+ * When wired through [networking.DevengNetworkingConfig.csrfTokenProvider], the client
+ * calls [getToken] on every POST/PUT/PATCH/DELETE and, if the result is non-null,
+ * attaches it under [networking.DevengNetworkingConfig.csrfHeaderName].
+ */
+public fun interface DevengCsrfTokenProvider {
+    public suspend fun getToken(): String?
+}

--- a/networking/src/commonMain/kotlin/session/DevengSessionRefresher.kt
+++ b/networking/src/commonMain/kotlin/session/DevengSessionRefresher.kt
@@ -1,0 +1,25 @@
+package networking.session
+
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Pluggable session-refresh hook called by [networking.DevengNetworkingModule] when a
+ * request comes back with HTTP 401.
+ *
+ * Return `true` if the refresh succeeded and the original request should be retried.
+ * Return `false` to let the 401 propagate as
+ * [error_handling.DevengUiError.UnauthorizedError].
+ *
+ * Concurrent 401s are deduplicated by a single-flight [kotlinx.coroutines.sync.Mutex]
+ * inside the client, so [refresh] is called at most once at a time. An internal
+ * coroutine-context marker also prevents recursion when a `refresh` implementation
+ * itself issues HTTP calls through the same client.
+ */
+public fun interface DevengSessionRefresher {
+    public suspend fun refresh(): Boolean
+}
+
+internal object RefreshGuard : CoroutineContext.Element {
+    override val key: CoroutineContext.Key<*> get() = Key
+    internal object Key : CoroutineContext.Key<RefreshGuard>
+}

--- a/networking/src/commonMain/kotlin/util/createHttpClient.kt
+++ b/networking/src/commonMain/kotlin/util/createHttpClient.kt
@@ -2,21 +2,32 @@ package networking.util
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.HttpSend
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.api.createClientPlugin
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.plugin
 import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import networking.DevengNetworkingConfig
+import networking.csrf.DevengCsrfTokenProvider
 import networking.di.CoreModule
+import networking.session.RefreshGuard
 
 internal fun createHttpClient(
     engine: HttpClientEngine,
     config: DevengNetworkingConfig = DevengNetworkingConfig()
 ): HttpClient {
-    return HttpClient(engine) {
+    val client = HttpClient(engine) {
         if (config.loggingEnabled) {
             install(Logging) {
                 logger = object : Logger {
@@ -40,5 +51,69 @@ internal fun createHttpClient(
         }
 
         install(WebSockets)
+
+        if (config.sessionRefresher != null) {
+            install(HttpSend)
+        }
+
+        config.csrfTokenProvider?.let { provider ->
+            install(buildCsrfPlugin(headerName = config.csrfHeaderName, provider = provider))
+        }
+
+        config.httpClientConfig?.invoke(this)
+    }
+
+    config.sessionRefresher?.let { refresher ->
+        val refreshMutex = Mutex()
+        // Read by subsequent/concurrent intercept invocations via the captured closure;
+        // IDE inspection only sees a single lambda body.
+        @Suppress("AssignedValueIsNeverRead")
+        var refreshGeneration = 0L
+
+        client.plugin(HttpSend).intercept { request ->
+            val genAtSend = refreshGeneration
+            val originalCall = execute(request)
+            if (originalCall.response.status != HttpStatusCode.Unauthorized) {
+                return@intercept originalCall
+            }
+
+            val inRefresh = currentCoroutineContext()[RefreshGuard.Key] != null
+            if (inRefresh) {
+                return@intercept originalCall
+            }
+
+            val refreshSucceeded = refreshMutex.withLock {
+                if (refreshGeneration != genAtSend) {
+                    true
+                } else {
+                    val success = withContext(RefreshGuard) { refresher.refresh() }
+                    if (success) refreshGeneration++
+                    success
+                }
+            }
+
+            if (refreshSucceeded) execute(request) else originalCall
+        }
+    }
+
+    return client
+}
+
+private fun buildCsrfPlugin(
+    headerName: String,
+    provider: DevengCsrfTokenProvider
+) = createClientPlugin("DevengCsrfPlugin") {
+    onRequest { request, _ ->
+        if (request.method.isMutating()) {
+            provider.getToken()?.let { token ->
+                request.headers[headerName] = token
+            }
+        }
     }
 }
+
+private fun HttpMethod.isMutating(): Boolean =
+    this == HttpMethod.Post ||
+        this == HttpMethod.Put ||
+        this == HttpMethod.Patch ||
+        this == HttpMethod.Delete

--- a/networking/src/commonMain/kotlin/util/helper.kt
+++ b/networking/src/commonMain/kotlin/util/helper.kt
@@ -92,9 +92,10 @@ public fun HttpMessageBuilder.setupCustomHeaders(customHeaders: Map<String, Stri
 }
 
 public fun HttpMessageBuilder.setupAllHeaders(module: DevengNetworkingModule) {
-    setupAuthorizationHeader(
-        token = module.getToken()
-    )
+    val token = module.getToken()
+    if (token.isNotBlank()) {
+        setupAuthorizationHeader(token = token)
+    }
 
     if (module.exceptionHandler?.locale != null) {
         setupLocaleHeader(

--- a/networking/src/wasmJsMain/kotlin/di/NetworkModule.wasmJs.kt
+++ b/networking/src/wasmJsMain/kotlin/di/NetworkModule.wasmJs.kt
@@ -2,12 +2,24 @@ package di
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.js.Js
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.toJsString
 import networking.DevengNetworkingConfig
 import networking.util.createHttpClient
 
 internal actual object NetworkModule {
+    @OptIn(ExperimentalWasmJsInterop::class)
     actual fun createHttpClient(config: DevengNetworkingConfig): HttpClient {
-        return createHttpClient(Js.create(), config)
+        val engine = if (config.wasmJsIncludeCredentials) {
+            Js.create {
+                configureRequest {
+                    credentials = "include".toJsString()
+                }
+            }
+        } else {
+            Js.create()
+        }
+        return createHttpClient(engine, config)
     }
 }
 


### PR DESCRIPTION
Lets consumers wire cookie-based auth without DNM owning the specifics.

- httpClientConfig: install consumer Ktor plugins (e.g. HttpCookies)
- sessionRefresher: single-flight refresh-on-401 via HttpSend
- csrfTokenProvider + csrfHeaderName: auto-attach on POST/PUT/PATCH/DELETE
- onUnauthorized: callback before the 401 exception is thrown
- wasmJsIncludeCredentials: credentials="include" on the wasmJs engine

Documented in README under "Advanced Features".