### PR TITLE
Add 10 supported locales and bump version to 2.13.71

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ android-minSdk = "24"
 android-compileSdk = "36"
 app-version-major = "2"
 app-version-code = "13"
-app-minor-version = "70"
+app-minor-version = "71"
 kotlin-serialization = "1.8.0"
 
 compose-plugin = "1.9.3"

--- a/networking/src/commonMain/kotlin/localization/Locale.kt
+++ b/networking/src/commonMain/kotlin/localization/Locale.kt
@@ -2,5 +2,15 @@ package networking.localization;
 
 public enum class Locale {
     EN,
-    TR;
+    TR,
+    ES,
+    PT,
+    DE,
+    ID,
+    KO,
+    JA,
+    AR,
+    FR,
+    IT,
+    HI;
 }


### PR DESCRIPTION
Extend the Locale enum from EN/TR to the app's full supported set (ES, PT, DE, ID, KO, JA, AR, FR, IT, HI) so the networking layer can send the device language to the backend via the existing language header. No exhaustive when() over Locale exists and LocalizationManager falls back to EN for locales without translations, so the additions are non-breaking.